### PR TITLE
Fix missing alias for translations

### DIFF
--- a/lib/i18n/globals.rb
+++ b/lib/i18n/globals.rb
@@ -25,5 +25,7 @@ module I18n
       end
       super(*args)
     end
+
+    alias t translate
   end
 end

--- a/lib/i18n/globals/version.rb
+++ b/lib/i18n/globals/version.rb
@@ -1,5 +1,5 @@
 module I18n
   module Globals
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end


### PR DESCRIPTION
I18n main lib provides two methods to translate copies. One is
`translate` and the other one is `t`. In this gem we are just overriding
`translate` but not `t`. So `t` is not adding global interpolation as
expected.

As you can see here, the original gem is doing that:

https://github.com/attilahorvath/i18n-globals/blob/master/lib/i18n/globals.rb#L118